### PR TITLE
feat: auto-fix-bug 워크플로우 완성 (PAT + 릴리즈 자동화)

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -141,10 +141,56 @@ jobs:
         run: |
           gh pr merge "${{ steps.pr.outputs.number }}" --merge --delete-branch
 
-      - name: Comment on issue
+      - name: Bump patch version and release
+        if: steps.changes.outputs.has_changes == 'true'
+        id: release
+        run: |
+          LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || echo "v1.0.0")
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v1.0.0"
+          fi
+
+          # Parse version and bump patch
+          MAJOR=$(echo "$LATEST_TAG" | sed 's/v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST_TAG" | sed 's/v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST_TAG" | sed 's/v//' | cut -d. -f3)
+          NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
         if: steps.changes.outputs.has_changes == 'true'
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "🤖 자동 수정 완료! PR ${{ steps.pr.outputs.url }} 이 머지되었습니다."
+          NEW_TAG="${{ steps.release.outputs.tag }}"
+          PREV_TAG="${{ steps.release.outputs.prev_tag }}"
+          ISSUE_TITLE="${{ steps.issue.outputs.title }}"
+
+          # Collect commits since last tag
+          git fetch origin main --tags
+          COMMITS=$(git log "${PREV_TAG}..origin/main" --oneline 2>/dev/null || echo "- fix: resolve #${ISSUE_NUMBER}")
+
+          gh release create "$NEW_TAG" \
+            --target main \
+            --title "${NEW_TAG} - bugfix" \
+            --notes "$(cat <<EOF
+          ## Bug Fix
+
+          - resolve #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+
+          ## Commits since ${PREV_TAG}
+
+          ${COMMITS}
+
+          ---
+          🤖 Auto-released by Claude Code
+          EOF
+          )"
+
+      - name: Close issue
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          gh issue close "$ISSUE_NUMBER" --comment "🤖 자동 수정 완료! PR ${{ steps.pr.outputs.url }} 머지 → ${{ steps.release.outputs.tag }} 릴리즈 완료."
 
       - name: Comment if no fix
         if: steps.changes.outputs.has_changes == 'false'


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` → `PAT_TOKEN` (PR 생성 권한 + CI 트리거 해결)
- 머지 후 패치 버전 자동 bump + 릴리즈 노트 생성
- 수정 완료 시 이슈 자동 close

## 전체 플로우
```
bug 라벨 → Claude Code 수정 → PR 생성 → CI 대기 → 리뷰 → 머지 → 태그/릴리즈 → 이슈 close
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)