### PR TITLE
refactor: Python → TypeScript Innertube API 자막 마이그레이션

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,6 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Install Python 3 + youtube-transcript-api (runtime dependency for transcript.ts)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
-    python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install youtube-transcript-api && \
-    apt-get purge -y python3-pip python3-venv && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/opt/venv/bin:$PATH"
-
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 

--- a/src/lib/youtube/transcript.ts
+++ b/src/lib/youtube/transcript.ts
@@ -1,53 +1,76 @@
 import { TranscriptEntry } from "./types";
-import * as childProcess from "child_process";
+
+const INNERTUBE_URL =
+  "https://www.youtube.com/youtubei/v1/player?pretend=true";
+
+const INNERTUBE_CONTEXT = {
+  client: {
+    clientName: "ANDROID",
+    clientVersion: "19.09.37",
+    androidSdkVersion: 30,
+    hl: "ja",
+    gl: "JP",
+  },
+};
+
+interface Json3Event {
+  segs?: { utf8: string }[];
+  tStartMs: number;
+  dDurationMs?: number;
+}
 
 export async function fetchTranscript(
   videoId: string,
   lang: string = "ja"
 ): Promise<TranscriptEntry[]> {
-  const pythonScript = `
-import json, sys
-from youtube_transcript_api import YouTubeTranscriptApi
-
-try:
-    ytt = YouTubeTranscriptApi()
-    result = ytt.fetch(sys.argv[1], languages=[sys.argv[2]])
-    entries = [{"text": s.text, "start": s.start, "duration": s.duration} for s in result.snippets]
-    print(json.dumps(entries))
-except Exception as e:
-    print(json.dumps({"error": str(e)}))
-    sys.exit(1)
-`;
-
-  return new Promise((resolve, reject) => {
-    childProcess.execFile(
-      "python3",
-      ["-c", pythonScript, videoId, lang],
-      { timeout: 15000 },
-      (error, stdout, stderr) => {
-        if (stdout.trim()) {
-          try {
-            const parsed = JSON.parse(stdout.trim());
-            if (parsed.error) {
-              reject(new Error(parsed.error));
-              return;
-            }
-            if (!error) {
-              resolve(parsed as TranscriptEntry[]);
-              return;
-            }
-          } catch {
-            // stdout is not valid JSON, fall through to error handling
-          }
-        }
-
-        if (error) {
-          reject(new Error(`자막 추출 실패: ${stderr || error.message}`));
-          return;
-        }
-
-        reject(new Error("자막 데이터 파싱 실패"));
-      }
-    );
+  // Step 1: Get caption tracks from Innertube player API
+  const playerRes = await fetch(INNERTUBE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      context: INNERTUBE_CONTEXT,
+      videoId,
+    }),
   });
+
+  if (!playerRes.ok) {
+    throw new Error(`Innertube player API 실패: ${playerRes.status}`);
+  }
+
+  const playerData = await playerRes.json();
+
+  const captionTracks: { baseUrl: string; languageCode: string }[] =
+    playerData?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [];
+
+  if (captionTracks.length === 0) {
+    throw new Error("자막 트랙을 찾을 수 없습니다");
+  }
+
+  // Find matching language track, fallback to first
+  const track =
+    captionTracks.find((t) => t.languageCode === lang) ?? captionTracks[0];
+
+  // Step 2: Fetch transcript in json3 format
+  const transcriptUrl = `${track.baseUrl}&fmt=json3`;
+  const transcriptRes = await fetch(transcriptUrl);
+
+  if (!transcriptRes.ok) {
+    throw new Error(`자막 데이터 요청 실패: ${transcriptRes.status}`);
+  }
+
+  const json3 = await transcriptRes.json();
+
+  const events: Json3Event[] = json3?.events ?? [];
+
+  // Parse json3 events into TranscriptEntry[]
+  const entries: TranscriptEntry[] = events
+    .filter((e) => e.segs && e.segs.length > 0)
+    .map((e) => ({
+      text: e.segs!.map((s) => s.utf8).join("").trim(),
+      start: e.tStartMs / 1000,
+      duration: (e.dDurationMs ?? 0) / 1000,
+    }))
+    .filter((e) => e.text.length > 0);
+
+  return entries;
 }

--- a/tests/unit/transcript.test.ts
+++ b/tests/unit/transcript.test.ts
@@ -1,68 +1,172 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchTranscript } from "@/lib/youtube/transcript";
 
-const { mockExecFile } = vi.hoisted(() => ({
-  mockExecFile: vi.fn(),
-}))
+function mockFetchResponses(
+  ...responses: Array<{ ok: boolean; status?: number; json?: unknown }>
+) {
+  const fetchMock = vi.fn();
+  for (const res of responses) {
+    fetchMock.mockResolvedValueOnce({
+      ok: res.ok,
+      status: res.status ?? (res.ok ? 200 : 500),
+      json: async () => res.json,
+    });
+  }
+  global.fetch = fetchMock;
+  return fetchMock;
+}
 
-vi.mock('child_process', () => ({
-  execFile: mockExecFile,
-}))
-
-import { fetchTranscript } from '@/lib/youtube/transcript'
-
-describe('fetchTranscript', () => {
+describe("fetchTranscript", () => {
   beforeEach(() => {
-    mockExecFile.mockReset()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('parses transcript entries from python output', async () => {
-    const mockEntries = [
-      { text: 'こんにちは', start: 0.0, duration: 2.5 },
-      { text: '世界', start: 2.5, duration: 3.0 },
-    ]
-
-    mockExecFile.mockImplementation(
-      (_cmd: string, _args: string[], _opts: object, callback: Function) => {
-        callback(null, JSON.stringify(mockEntries), '')
+  it("parses transcript entries from Innertube json3 response", async () => {
+    const playerJson = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            { baseUrl: "https://example.com/timedtext", languageCode: "ja" },
+          ],
+        },
       },
-    )
+    };
+    const json3 = {
+      events: [
+        {
+          tStartMs: 0,
+          dDurationMs: 2500,
+          segs: [{ utf8: "こんにちは" }],
+        },
+        {
+          tStartMs: 2500,
+          dDurationMs: 3000,
+          segs: [{ utf8: "世界" }],
+        },
+      ],
+    };
 
-    const result = await fetchTranscript('testVideoId', 'ja')
+    mockFetchResponses(
+      { ok: true, json: playerJson },
+      { ok: true, json: json3 }
+    );
 
-    expect(result).toEqual(mockEntries)
-    expect(mockExecFile).toHaveBeenCalledWith(
-      'python3',
-      expect.arrayContaining(['testVideoId', 'ja']),
-      expect.any(Object),
-      expect.any(Function),
-    )
-  })
+    const result = await fetchTranscript("testVideoId", "ja");
 
-  it('throws error when python script fails', async () => {
-    mockExecFile.mockImplementation(
-      (_cmd: string, _args: string[], _opts: object, callback: Function) => {
-        callback(new Error('Process failed'), '', '자막 추출 실패')
+    expect(result).toEqual([
+      { text: "こんにちは", start: 0, duration: 2.5 },
+      { text: "世界", start: 2.5, duration: 3 },
+    ]);
+  });
+
+  it("throws error when no caption tracks are found", async () => {
+    const playerJson = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [],
+        },
       },
-    )
+    };
 
-    await expect(fetchTranscript('testVideoId', 'ja')).rejects.toThrow(
-      '자막 추출 실패',
-    )
-  })
+    mockFetchResponses({ ok: true, json: playerJson });
 
-  it('throws error when python returns error json', async () => {
-    mockExecFile.mockImplementation(
-      (_cmd: string, _args: string[], _opts: object, callback: Function) => {
-        callback(
-          { code: 1 },
-          JSON.stringify({ error: 'No transcript found' }),
-          '',
-        )
+    await expect(fetchTranscript("testVideoId", "ja")).rejects.toThrow(
+      "자막 트랙을 찾을 수 없습니다"
+    );
+  });
+
+  it("throws error when Innertube player API fails", async () => {
+    mockFetchResponses({ ok: false, status: 403 });
+
+    await expect(fetchTranscript("testVideoId", "ja")).rejects.toThrow(
+      "Innertube player API 실패: 403"
+    );
+  });
+
+  it("filters out empty segments", async () => {
+    const playerJson = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            { baseUrl: "https://example.com/timedtext", languageCode: "ja" },
+          ],
+        },
       },
-    )
+    };
+    const json3 = {
+      events: [
+        {
+          tStartMs: 0,
+          dDurationMs: 1000,
+          segs: [{ utf8: "テスト" }],
+        },
+        {
+          tStartMs: 1000,
+          dDurationMs: 500,
+          segs: [{ utf8: "  " }],
+        },
+        {
+          tStartMs: 1500,
+          dDurationMs: 0,
+        },
+        {
+          tStartMs: 2000,
+          dDurationMs: 2000,
+          segs: [{ utf8: "有効" }],
+        },
+      ],
+    };
 
-    await expect(fetchTranscript('testVideoId', 'ja')).rejects.toThrow(
-      'No transcript found',
-    )
-  })
-})
+    mockFetchResponses(
+      { ok: true, json: playerJson },
+      { ok: true, json: json3 }
+    );
+
+    const result = await fetchTranscript("testVideoId", "ja");
+
+    expect(result).toEqual([
+      { text: "テスト", start: 0, duration: 1 },
+      { text: "有効", start: 2, duration: 2 },
+    ]);
+  });
+
+  it("falls back to first track when requested language is not found", async () => {
+    const playerJson = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            { baseUrl: "https://example.com/timedtext", languageCode: "en" },
+          ],
+        },
+      },
+    };
+    const json3 = {
+      events: [
+        {
+          tStartMs: 0,
+          dDurationMs: 2000,
+          segs: [{ utf8: "Hello" }],
+        },
+      ],
+    };
+
+    mockFetchResponses(
+      { ok: true, json: playerJson },
+      { ok: true, json: json3 }
+    );
+
+    const result = await fetchTranscript("testVideoId", "ja");
+
+    expect(result).toEqual([{ text: "Hello", start: 0, duration: 2 }]);
+  });
+
+  it("handles missing captions field gracefully", async () => {
+    const playerJson = { videoDetails: { videoId: "test" } };
+
+    mockFetchResponses({ ok: true, json: playerJson });
+
+    await expect(fetchTranscript("testVideoId", "ja")).rejects.toThrow(
+      "자막 트랙을 찾을 수 없습니다"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Oracle Cloud IP YouTube 차단으로 인한 `youtube-transcript-api` (Python) 동작 불가 문제 해결
- Python subprocess 제거, YouTube Innertube API (`/youtubei/v1/player`, Android client context) 직접 호출하는 순수 TypeScript 구현으로 교체
- Dockerfile에서 Python/pip/venv 설치 블록 제거 → Docker 이미지 크기 감소

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `src/lib/youtube/transcript.ts` | `child_process.execFile("python3", ...)` → 2단계 fetch (Innertube player → json3 파싱) |
| `tests/unit/transcript.test.ts` | `child_process` mock → `global.fetch` mock, 6개 테스트 |
| `Dockerfile` | Python 런타임 설치 블록 삭제 |

## Test plan
- [x] `pnpm test` — 57 tests 전체 통과
- [x] `pnpm build` — 빌드 성공
- [ ] 배포 후 `https://kiko.bini59.dev`에서 자막 로딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)