### PR TITLE
feat: GA4 애널리틱스 연동 (@next/third-parties)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,1 +1,3 @@
 YOUTUBE_API_KEY=your_youtube_api_key_here
+# (선택) GA4 측정 ID override. 미설정 시 코드 기본값(G-FCYK67GKZS) 사용.
+# NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@next/third-parties": "14.2.35",
     "lucide-react": "^1.23.0",
     "next": "14.2.35",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@next/third-parties':
+        specifier: 14.2.35
+        version: 14.2.35(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       lucide-react:
         specifier: ^1.23.0
         version: 1.23.0(react@18.3.1)
@@ -501,6 +504,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@14.2.35':
+    resolution: {integrity: sha512-dG1J+4uYungW1snGViN7tAVyfO0iz0zoB+sqsLMUo8kwR0NED2muLTMbOChmrliHhzOFj6ZpHfkvhy5NJjFvSQ==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0
+      react: ^18.2.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2405,6 +2414,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3018,6 +3030,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@14.2.33':
     optional: true
+
+  '@next/third-parties@14.2.35(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5165,6 +5183,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  third-party-capital@1.0.20: {}
 
   tinybench@2.9.0: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from "next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import "./globals.css";
+
+// GA4 측정 ID. 공개 식별자라 기본값을 코드에 두고, 필요 시 NEXT_PUBLIC_GA_ID로 override.
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID ?? "G-FCYK67GKZS";
+// 개발 환경 데이터 오염을 막기 위해 프로덕션 빌드에서만 로드.
+const GA_ENABLED = process.env.NODE_ENV === "production" && !!GA_ID;
 
 export const metadata: Metadata = {
   title: "Kiko - 일본어 학습 플랫폼",
@@ -14,6 +20,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="antialiased">{children}</body>
+      {GA_ENABLED ? <GoogleAnalytics gaId={GA_ID} /> : null}
     </html>
   );
 }


### PR DESCRIPTION
## 개요
Kiko 사이트(kiko.bini59.dev)에 GA4 웹 분석을 연동합니다. GTM 없이 `@next/third-parties`의 `GoogleAnalytics` 컴포넌트로 gtag를 직접 삽입합니다.

## 변경 사항
- `@next/third-parties@14.2.35` 의존성 추가 (package.json + pnpm-lock.yaml)
- `src/app/layout.tsx`: `RootLayout`에 `<GoogleAnalytics />` 삽입
  - 측정 ID `G-FCYK67GKZS` (bini59.dev 조직 > kiko 속성 > `kiko web` 스트림)
  - `NEXT_PUBLIC_GA_ID` 환경변수로 override 가능 (측정 ID는 공개 식별자라 기본값을 코드에 둠)
  - `NODE_ENV === "production"` 일 때만 로드 → 개발 서버(`pnpm dev`) 데이터 오염 방지
- `.env.production.example`: override 항목 문서화

## GA4 설정 (완료)
- 조직: **bini59.dev** (업무용 IIA/Counterpoint와 분리)
- 속성: `kiko`, 시간대 GMT+09:00, 통화 ₩
- 웹 데이터 스트림: `https://kiko.bini59.dev`, 측정 ID `G-FCYK67GKZS`

## 검증
- `next lint`: ✅ 통과
- `next build`: ✅ 성공
- 단위/통합 테스트: 63/64 통과
  - ⚠️ `tests/unit/script-panel.test.tsx`의 `scrollIntoView` 1건 실패는 **이 PR과 무관한 기존 이슈**(main에서도 동일 실패). jsdom `scrollIntoView` 스텁 문제로, #18에서 별도 수정 중.

## 배포 후 확인
- 병합 → main 배포 후 `https://www.googletagmanager.com/gtag/js?id=G-FCYK67GKZS` 응답 또는 GA4 실시간 보고서로 히트 확인
