### PR TITLE
fix: 자막 추출을 yt-dlp 기반으로 교체

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,13 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# yt-dlp standalone 바이너리 (Python 불필요, Innertube 변경을 따라가 안 깨짐)
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux \
+       -o /usr/local/bin/yt-dlp \
+    && chmod a+rx /usr/local/bin/yt-dlp \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiko",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 30300",

--- a/src/lib/youtube/transcript.ts
+++ b/src/lib/youtube/transcript.ts
@@ -1,82 +1,87 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { mkdtemp, readdir, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
 import { TranscriptEntry } from "./types";
 
-const INNERTUBE_URL =
-  "https://www.youtube.com/youtubei/v1/player?pretend=true";
+const execFileAsync = promisify(execFile);
 
-const INNERTUBE_CONTEXT = {
-  client: {
-    clientName: "ANDROID",
-    clientVersion: "19.09.37",
-    androidSdkVersion: 30,
-    hl: "ja",
-    gl: "JP",
-  },
-};
+// yt-dlp가 Innertube 변경을 따라가므로 직접 구현보다 안 깨진다.
+const YTDLP = process.env.YTDLP_PATH || "yt-dlp";
 
-interface Json3Event {
-  segs?: { utf8: string }[];
-  tStartMs: number;
-  dDurationMs?: number;
+const SRT_TIME =
+  /(\d{2}):(\d{2}):(\d{2})[,.](\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})[,.](\d{3})/;
+
+/** SRT 블록을 TranscriptEntry[]로 파싱한다. */
+export function parseSrt(srt: string): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = [];
+
+  for (const block of srt.replace(/\r/g, "").trim().split(/\n\n+/)) {
+    const lines = block.split("\n");
+    const timeIdx = lines.findIndex((l) => l.includes("-->"));
+    if (timeIdx === -1) continue;
+
+    const m = lines[timeIdx].match(SRT_TIME);
+    if (!m) continue;
+
+    const start = +m[1] * 3600 + +m[2] * 60 + +m[3] + +m[4] / 1000;
+    const end = +m[5] * 3600 + +m[6] * 60 + +m[7] + +m[8] / 1000;
+
+    const text = lines
+      .slice(timeIdx + 1)
+      .join(" ")
+      .replace(/<[^>]+>/g, "") // vtt→srt 변환 시 남는 인라인 태그 제거
+      .trim();
+    if (!text) continue;
+
+    entries.push({ text, start, duration: Math.max(0, end - start) });
+  }
+
+  return entries;
 }
 
 export async function fetchTranscript(
   videoId: string,
   lang: string = "ja"
 ): Promise<TranscriptEntry[]> {
-  // Step 1: Get caption tracks from Innertube player API
-  const playerRes = await fetch(INNERTUBE_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      context: INNERTUBE_CONTEXT,
-      videoId,
-    }),
-  });
+  const dir = await mkdtemp(join(tmpdir(), "kiko-sub-"));
 
-  if (!playerRes.ok) {
-    throw new Error(`Innertube player API 실패: ${playerRes.status}`);
+  try {
+    await execFileAsync(
+      YTDLP,
+      [
+        "--write-auto-subs",
+        "--write-subs",
+        "--sub-langs",
+        `${lang}.*,${lang}`,
+        "--skip-download",
+        "--convert-subs",
+        "srt",
+        "--no-playlist",
+        "-o",
+        join(dir, "%(id)s.%(ext)s"),
+        "--",
+        `https://www.youtube.com/watch?v=${videoId}`,
+      ],
+      { timeout: 60_000, maxBuffer: 10 * 1024 * 1024 }
+    );
+
+    const srtFile = (await readdir(dir)).find((f) => f.endsWith(".srt"));
+    if (!srtFile) throw new Error("이 영상에는 자막이 없습니다");
+
+    const entries = parseSrt(await readFile(join(dir, srtFile), "utf-8"));
+    if (entries.length === 0) throw new Error("이 영상에는 자막이 없습니다");
+
+    return entries;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("yt-dlp가 설치되어 있지 않습니다");
+    }
+    throw error instanceof Error
+      ? error
+      : new Error("자막을 불러올 수 없습니다");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
   }
-
-  const playerData = await playerRes.json();
-
-  const captionTracks: { baseUrl: string; languageCode: string; kind?: string }[] =
-    playerData?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [];
-
-  if (captionTracks.length === 0) {
-    throw new Error("자막 트랙을 찾을 수 없습니다");
-  }
-
-  // Prefer manual lang track > lang auto (asr) track > first track
-  const track =
-    captionTracks.find((t) => t.languageCode === lang && t.kind !== "asr") ??
-    captionTracks.find((t) => t.languageCode === lang) ??
-    captionTracks[0];
-
-  // Step 2: Fetch transcript in json3 format
-  const transcriptUrl = `${track.baseUrl}&fmt=json3`;
-  const transcriptRes = await fetch(transcriptUrl);
-
-  if (!transcriptRes.ok) {
-    throw new Error(`자막 데이터 요청 실패: ${transcriptRes.status}`);
-  }
-
-  const json3 = await transcriptRes.json();
-
-  const events: Json3Event[] = json3?.events ?? [];
-
-  // Parse json3 events into TranscriptEntry[]
-  const entries: TranscriptEntry[] = events
-    .filter((e) => e.segs && e.segs.length > 0)
-    .map((e) => ({
-      text: e.segs!.map((s) => s.utf8).join("").trim(),
-      start: e.tStartMs / 1000,
-      duration: (e.dDurationMs ?? 0) / 1000,
-    }))
-    .filter((e) => e.text.length > 0);
-
-  if (entries.length === 0) {
-    throw new Error("이 영상에는 자막이 없습니다");
-  }
-
-  return entries;
 }

--- a/tests/unit/transcript.test.ts
+++ b/tests/unit/transcript.test.ts
@@ -1,249 +1,59 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchTranscript } from "@/lib/youtube/transcript";
+import { describe, it, expect } from "vitest";
+import { parseSrt } from "@/lib/youtube/transcript";
 
-function mockFetchResponses(
-  ...responses: Array<{ ok: boolean; status?: number; json?: unknown }>
-) {
-  const fetchMock = vi.fn();
-  for (const res of responses) {
-    fetchMock.mockResolvedValueOnce({
-      ok: res.ok,
-      status: res.status ?? (res.ok ? 200 : 500),
-      json: async () => res.json,
-    });
-  }
-  global.fetch = fetchMock;
-  return fetchMock;
-}
+describe("parseSrt", () => {
+  it("parses SRT blocks into transcript entries", () => {
+    const srt = [
+      "1",
+      "00:00:00,000 --> 00:00:02,500",
+      "こんにちは",
+      "",
+      "2",
+      "00:00:02,500 --> 00:00:05,500",
+      "世界",
+      "",
+    ].join("\n");
 
-describe("fetchTranscript", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("parses transcript entries from Innertube json3 response", async () => {
-    const playerJson = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            { baseUrl: "https://example.com/timedtext", languageCode: "ja" },
-          ],
-        },
-      },
-    };
-    const json3 = {
-      events: [
-        {
-          tStartMs: 0,
-          dDurationMs: 2500,
-          segs: [{ utf8: "こんにちは" }],
-        },
-        {
-          tStartMs: 2500,
-          dDurationMs: 3000,
-          segs: [{ utf8: "世界" }],
-        },
-      ],
-    };
-
-    mockFetchResponses(
-      { ok: true, json: playerJson },
-      { ok: true, json: json3 }
-    );
-
-    const result = await fetchTranscript("testVideoId", "ja");
-
-    expect(result).toEqual([
+    expect(parseSrt(srt)).toEqual([
       { text: "こんにちは", start: 0, duration: 2.5 },
       { text: "世界", start: 2.5, duration: 3 },
     ]);
   });
 
-  it("throws error when no caption tracks are found", async () => {
-    const playerJson = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [],
-        },
-      },
-    };
+  it("joins multi-line cue text and strips inline tags", () => {
+    const srt = [
+      "1",
+      "00:00:01,000 --> 00:00:03,000",
+      "<c>有効</c>な",
+      "テスト",
+      "",
+    ].join("\n");
 
-    mockFetchResponses({ ok: true, json: playerJson });
-
-    await expect(fetchTranscript("testVideoId", "ja")).rejects.toThrow(
-      "자막 트랙을 찾을 수 없습니다"
-    );
-  });
-
-  it("throws error when Innertube player API fails", async () => {
-    mockFetchResponses({ ok: false, status: 403 });
-
-    await expect(fetchTranscript("testVideoId", "ja")).rejects.toThrow(
-      "Innertube player API 실패: 403"
-    );
-  });
-
-  it("filters out empty segments", async () => {
-    const playerJson = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            { baseUrl: "https://example.com/timedtext", languageCode: "ja" },
-          ],
-        },
-      },
-    };
-    const json3 = {
-      events: [
-        {
-          tStartMs: 0,
-          dDurationMs: 1000,
-          segs: [{ utf8: "テスト" }],
-        },
-        {
-          tStartMs: 1000,
-          dDurationMs: 500,
-          segs: [{ utf8: "  " }],
-        },
-        {
-          tStartMs: 1500,
-          dDurationMs: 0,
-        },
-        {
-          tStartMs: 2000,
-          dDurationMs: 2000,
-          segs: [{ utf8: "有効" }],
-        },
-      ],
-    };
-
-    mockFetchResponses(
-      { ok: true, json: playerJson },
-      { ok: true, json: json3 }
-    );
-
-    const result = await fetchTranscript("testVideoId", "ja");
-
-    expect(result).toEqual([
-      { text: "テスト", start: 0, duration: 1 },
-      { text: "有効", start: 2, duration: 2 },
+    expect(parseSrt(srt)).toEqual([
+      { text: "有効な テスト", start: 1, duration: 2 },
     ]);
   });
 
-  it("falls back to first track when requested language is not found", async () => {
-    const playerJson = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            { baseUrl: "https://example.com/timedtext", languageCode: "en" },
-          ],
-        },
-      },
-    };
-    const json3 = {
-      events: [
-        {
-          tStartMs: 0,
-          dDurationMs: 2000,
-          segs: [{ utf8: "Hello" }],
-        },
-      ],
-    };
+  it("skips blocks with no text or no timestamp", () => {
+    const srt = [
+      "1",
+      "00:00:00,000 --> 00:00:01,000",
+      "テスト",
+      "",
+      "2",
+      "00:00:01,000 --> 00:00:02,000",
+      "   ",
+      "",
+      "NOTE this has no timestamp",
+      "",
+    ].join("\n");
 
-    mockFetchResponses(
-      { ok: true, json: playerJson },
-      { ok: true, json: json3 }
-    );
-
-    const result = await fetchTranscript("testVideoId", "ja");
-
-    expect(result).toEqual([{ text: "Hello", start: 0, duration: 2 }]);
+    expect(parseSrt(srt)).toEqual([
+      { text: "テスト", start: 0, duration: 1 },
+    ]);
   });
 
-  it("handles missing captions field gracefully", async () => {
-    const playerJson = { videoDetails: { videoId: "test" } };
-
-    mockFetchResponses({ ok: true, json: playerJson });
-
-    await expect(fetchTranscript("testVideoId", "ja")).rejects.toThrow(
-      "자막 트랙을 찾을 수 없습니다"
-    );
-  });
-
-  it("prefers manual ja track over ja asr track", async () => {
-    const playerJson = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            { baseUrl: "https://example.com/asr", languageCode: "ja", kind: "asr" },
-            { baseUrl: "https://example.com/manual", languageCode: "ja" },
-          ],
-        },
-      },
-    };
-    const json3 = {
-      events: [{ tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "手動" }] }],
-    };
-
-    const fetchMock = mockFetchResponses(
-      { ok: true, json: playerJson },
-      { ok: true, json: json3 }
-    );
-
-    await fetchTranscript("testVideoId", "ja");
-
-    expect(fetchMock.mock.calls[1][0]).toContain("https://example.com/manual");
-  });
-
-  it("uses ja asr track when no manual ja track exists", async () => {
-    const playerJson = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            { baseUrl: "https://example.com/en", languageCode: "en" },
-            { baseUrl: "https://example.com/asr", languageCode: "ja", kind: "asr" },
-          ],
-        },
-      },
-    };
-    const json3 = {
-      events: [{ tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "自動" }] }],
-    };
-
-    const fetchMock = mockFetchResponses(
-      { ok: true, json: playerJson },
-      { ok: true, json: json3 }
-    );
-
-    await fetchTranscript("testVideoId", "ja");
-
-    expect(fetchMock.mock.calls[1][0]).toContain("https://example.com/asr");
-  });
-
-  it("throws when transcript parses to zero entries", async () => {
-    const playerJson = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            { baseUrl: "https://example.com/timedtext", languageCode: "ja" },
-          ],
-        },
-      },
-    };
-    const json3 = {
-      events: [
-        { tStartMs: 0, dDurationMs: 500, segs: [{ utf8: "  " }] },
-        { tStartMs: 500, dDurationMs: 500 },
-      ],
-    };
-
-    mockFetchResponses(
-      { ok: true, json: playerJson },
-      { ok: true, json: json3 }
-    );
-
-    await expect(fetchTranscript("testVideoId", "ja")).rejects.toThrow(
-      "이 영상에는 자막이 없습니다"
-    );
+  it("returns empty array for empty input", () => {
+    expect(parseSrt("")).toEqual([]);
   });
 });


### PR DESCRIPTION
## 개요
Innertube player API를 직접 호출하던 자막 추출을 **yt-dlp 기반**으로 교체한다. yt-dlp는 Innertube 변경사항을 계속 따라가므로 직접 구현보다 훨씬 안 깨진다.

## 변경
- **`src/lib/youtube/transcript.ts`**: `fetchTranscript`가 yt-dlp 서브프로세스로 SRT를 받아 파싱. 시그니처 동일 → route/caller 무변경. SRT 파싱은 순수 `parseSrt()`로 분리(테스트 가능).
- **`Dockerfile`**: runner 스테이지에 yt-dlp standalone 바이너리 설치 (Python 불필요, 항상 최신).
- **`tests/unit/transcript.test.ts`**: 사라진 Innertube fetch 목 테스트 → `parseSrt` 단위 테스트로 교체.
- version 1.2.0 → 1.2.1

## Test plan
- [x] `parseSrt` 단위 테스트 통과
- [x] typecheck 통과
- [x] E2E는 `/api/youtube`를 목킹하므로 CI(yt-dlp 없음)에서 영향 없음
- [ ] 배포 후 실제 영상으로 자막 로드 확인 (프로덕션엔 yt-dlp 바이너리 포함)