### PR TITLE
fix: yt-dlp 바이너리 아키텍처별 설치 (aarch64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
 # yt-dlp standalone 바이너리 (Python 불필요, Innertube 변경을 따라가 안 깨짐)
+# 아키텍처별 릴리즈 자산을 선택 (러너는 aarch64)
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && curl -fL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux \
+    && case "$(uname -m)" in \
+         aarch64) YTDLP_ASSET=yt-dlp_linux_aarch64 ;; \
+         x86_64)  YTDLP_ASSET=yt-dlp_linux ;; \
+         *) echo "unsupported arch: $(uname -m)" && exit 1 ;; \
+       esac \
+    && curl -fL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/${YTDLP_ASSET}" \
        -o /usr/local/bin/yt-dlp \
     && chmod a+rx /usr/local/bin/yt-dlp \
     && rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiko",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 30300",


### PR DESCRIPTION
## 문제
1.2.1 배포 후 컨테이너에서 `yt-dlp` 실행 시 `exec format error`. 러너는 **aarch64**인데 x86_64용 `yt-dlp_linux`를 받았음.

## 수정
Dockerfile에서 `uname -m`으로 아키텍처를 감지해 `yt-dlp_linux_aarch64`(arm64) / `yt-dlp_linux`(x86_64) 자산을 선택.

## Test plan
- [x] 로컬 컨테이너 arch = aarch64 확인
- [ ] 배포 후 `docker exec kiko yt-dlp --version` 정상 출력