### PR TITLE
feat: 자막 fetch VPN 프록시 경유 + json3 파싱

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,12 @@ jobs:
       - name: Create .env.production
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
-        run: echo "YOUTUBE_API_KEY=${YOUTUBE_API_KEY}" > .env.production
+          WIREGUARD_PRIVATE_KEY: ${{ secrets.WIREGUARD_PRIVATE_KEY }}
+        run: |
+          {
+            echo "YOUTUBE_API_KEY=${YOUTUBE_API_KEY}"
+            echo "WIREGUARD_PRIVATE_KEY=${WIREGUARD_PRIVATE_KEY}"
+          } > .env.production
 
       - name: Deploy
         run: docker compose up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,28 @@
 services:
+  # Surfshark WireGuard VPN. yt-dlp 자막 요청만 이 VPN을 경유해 YouTube 봇 차단을 우회한다.
+  # 내장 HTTP 프록시(:8888)를 kiko가 YTDLP_PROXY로 사용.
+  gluetun:
+    image: qmcgaw/gluetun:latest
+    container_name: kiko-gluetun
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    environment:
+      VPN_SERVICE_PROVIDER: custom
+      VPN_TYPE: wireguard
+      WIREGUARD_ENDPOINT_IP: "146.70.205.117" # jp-tok.prod.surfshark.com
+      WIREGUARD_ENDPOINT_PORT: "51820"
+      WIREGUARD_PUBLIC_KEY: "YJSjrc/WWOjQUyUi4iYcHb7LsWWoCY+2fK8/8VtC/BY="
+      WIREGUARD_ADDRESSES: "10.14.0.2/16"
+      HTTPPROXY: "on"
+      # WIREGUARD_PRIVATE_KEY 는 .env.production(GitHub Secret)에서 주입
+    env_file:
+      - .env.production
+    restart: unless-stopped
+    networks:
+      - api-net
+
   kiko:
     build: .
     container_name: kiko
@@ -6,6 +30,10 @@ services:
       - "30301:30301"
     env_file:
       - .env.production
+    environment:
+      YTDLP_PROXY: "http://kiko-gluetun:8888"
+    depends_on:
+      - gluetun
     restart: unless-stopped
     networks:
       - api-net

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiko",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 30300",

--- a/src/lib/youtube/transcript.ts
+++ b/src/lib/youtube/transcript.ts
@@ -9,36 +9,28 @@ const execFileAsync = promisify(execFile);
 
 // yt-dlp가 Innertube 변경을 따라가므로 직접 구현보다 안 깨진다.
 const YTDLP = process.env.YTDLP_PATH || "yt-dlp";
+// 설정 시 자막 요청만 이 프록시(gluetun VPN)를 경유한다. YouTube의 클라우드 IP 봇 차단 우회.
+const YTDLP_PROXY = process.env.YTDLP_PROXY;
 
-const SRT_TIME =
-  /(\d{2}):(\d{2}):(\d{2})[,.](\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})[,.](\d{3})/;
+interface Json3Event {
+  segs?: { utf8: string }[];
+  tStartMs: number;
+  dDurationMs?: number;
+}
 
-/** SRT 블록을 TranscriptEntry[]로 파싱한다. */
-export function parseSrt(srt: string): TranscriptEntry[] {
-  const entries: TranscriptEntry[] = [];
-
-  for (const block of srt.replace(/\r/g, "").trim().split(/\n\n+/)) {
-    const lines = block.split("\n");
-    const timeIdx = lines.findIndex((l) => l.includes("-->"));
-    if (timeIdx === -1) continue;
-
-    const m = lines[timeIdx].match(SRT_TIME);
-    if (!m) continue;
-
-    const start = +m[1] * 3600 + +m[2] * 60 + +m[3] + +m[4] / 1000;
-    const end = +m[5] * 3600 + +m[6] * 60 + +m[7] + +m[8] / 1000;
-
-    const text = lines
-      .slice(timeIdx + 1)
-      .join(" ")
-      .replace(/<[^>]+>/g, "") // vtt→srt 변환 시 남는 인라인 태그 제거
-      .trim();
-    if (!text) continue;
-
-    entries.push({ text, start, duration: Math.max(0, end - start) });
-  }
-
-  return entries;
+/**
+ * YouTube json3 자막을 TranscriptEntry[]로 파싱한다.
+ * 자동 자막의 롤업 이벤트는 seg가 개행("\n")뿐이라 trim 후 빈 문자열로 걸러진다.
+ */
+export function parseJson3(json: { events?: Json3Event[] }): TranscriptEntry[] {
+  return (json.events ?? [])
+    .filter((e) => e.segs && e.segs.length > 0)
+    .map((e) => ({
+      text: e.segs!.map((s) => s.utf8).join("").trim(),
+      start: e.tStartMs / 1000,
+      duration: (e.dDurationMs ?? 0) / 1000,
+    }))
+    .filter((e) => e.text.length > 0);
 }
 
 export async function fetchTranscript(
@@ -48,29 +40,36 @@ export async function fetchTranscript(
   const dir = await mkdtemp(join(tmpdir(), "kiko-sub-"));
 
   try {
-    await execFileAsync(
-      YTDLP,
-      [
-        "--write-auto-subs",
-        "--write-subs",
-        "--sub-langs",
-        `${lang}.*,${lang}`,
-        "--skip-download",
-        "--convert-subs",
-        "srt",
-        "--no-playlist",
-        "-o",
-        join(dir, "%(id)s.%(ext)s"),
-        "--",
-        `https://www.youtube.com/watch?v=${videoId}`,
-      ],
-      { timeout: 60_000, maxBuffer: 10 * 1024 * 1024 }
-    );
+    const args = [
+      "--write-auto-subs",
+      "--write-subs",
+      "--sub-langs",
+      `${lang}.*,${lang}`,
+      "--sub-format",
+      "json3",
+      "--skip-download",
+      "--no-playlist",
+      "-o",
+      join(dir, "%(id)s.%(ext)s"),
+    ];
+    if (YTDLP_PROXY) args.push("--proxy", YTDLP_PROXY);
+    args.push("--", `https://www.youtube.com/watch?v=${videoId}`);
 
-    const srtFile = (await readdir(dir)).find((f) => f.endsWith(".srt"));
-    if (!srtFile) throw new Error("이 영상에는 자막이 없습니다");
+    await execFileAsync(YTDLP, args, {
+      timeout: 60_000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
 
-    const entries = parseSrt(await readFile(join(dir, srtFile), "utf-8"));
+    const files = await readdir(dir);
+    // 원본 언어 트랙(<lang>) 우선, 없으면 <lang>-orig 등, 없으면 아무 json3
+    const pick =
+      files.find((f) => f.endsWith(`.${lang}.json3`)) ??
+      files.find((f) => f.includes(`.${lang}`) && f.endsWith(".json3")) ??
+      files.find((f) => f.endsWith(".json3"));
+    if (!pick) throw new Error("이 영상에는 자막이 없습니다");
+
+    const json = JSON.parse(await readFile(join(dir, pick), "utf-8"));
+    const entries = parseJson3(json);
     if (entries.length === 0) throw new Error("이 영상에는 자막이 없습니다");
 
     return entries;

--- a/tests/unit/transcript.test.ts
+++ b/tests/unit/transcript.test.ts
@@ -1,59 +1,55 @@
 import { describe, it, expect } from "vitest";
-import { parseSrt } from "@/lib/youtube/transcript";
+import { parseJson3 } from "@/lib/youtube/transcript";
 
-describe("parseSrt", () => {
-  it("parses SRT blocks into transcript entries", () => {
-    const srt = [
-      "1",
-      "00:00:00,000 --> 00:00:02,500",
-      "こんにちは",
-      "",
-      "2",
-      "00:00:02,500 --> 00:00:05,500",
-      "世界",
-      "",
-    ].join("\n");
+describe("parseJson3", () => {
+  it("parses json3 events into transcript entries", () => {
+    const json = {
+      events: [
+        { tStartMs: 0, dDurationMs: 2500, segs: [{ utf8: "こんにちは" }] },
+        { tStartMs: 2500, dDurationMs: 3000, segs: [{ utf8: "世界" }] },
+      ],
+    };
 
-    expect(parseSrt(srt)).toEqual([
+    expect(parseJson3(json)).toEqual([
       { text: "こんにちは", start: 0, duration: 2.5 },
       { text: "世界", start: 2.5, duration: 3 },
     ]);
   });
 
-  it("joins multi-line cue text and strips inline tags", () => {
-    const srt = [
-      "1",
-      "00:00:01,000 --> 00:00:03,000",
-      "<c>有効</c>な",
-      "テスト",
-      "",
-    ].join("\n");
+  it("joins multiple segs into one line", () => {
+    const json = {
+      events: [
+        {
+          tStartMs: 640,
+          dDurationMs: 8760,
+          segs: [{ utf8: "無敵" }, { utf8: "の" }, { utf8: "笑顔" }],
+        },
+      ],
+    };
 
-    expect(parseSrt(srt)).toEqual([
-      { text: "有効な テスト", start: 1, duration: 2 },
+    expect(parseJson3(json)).toEqual([
+      { text: "無敵の笑顔", start: 0.64, duration: 8.76 },
     ]);
   });
 
-  it("skips blocks with no text or no timestamp", () => {
-    const srt = [
-      "1",
-      "00:00:00,000 --> 00:00:01,000",
-      "テスト",
-      "",
-      "2",
-      "00:00:01,000 --> 00:00:02,000",
-      "   ",
-      "",
-      "NOTE this has no timestamp",
-      "",
-    ].join("\n");
+  it("filters out auto-caption rollup events (newline-only segs)", () => {
+    const json = {
+      events: [
+        { tStartMs: 640, dDurationMs: 4350, segs: [{ utf8: "本編" }] },
+        { tStartMs: 4990, dDurationMs: 10, segs: [{ utf8: "\n" }] },
+        { tStartMs: 5000, dDurationMs: 4400, segs: [{ utf8: "続き" }] },
+        { tStartMs: 9400, dDurationMs: 0 }, // no segs (window definition)
+      ],
+    };
 
-    expect(parseSrt(srt)).toEqual([
-      { text: "テスト", start: 0, duration: 1 },
+    expect(parseJson3(json)).toEqual([
+      { text: "本編", start: 0.64, duration: 4.35 },
+      { text: "続き", start: 5, duration: 4.4 },
     ]);
   });
 
-  it("returns empty array for empty input", () => {
-    expect(parseSrt("")).toEqual([]);
+  it("returns empty array when there are no events", () => {
+    expect(parseJson3({})).toEqual([]);
+    expect(parseJson3({ events: [] })).toEqual([]);
   });
 });


### PR DESCRIPTION
## 배경
YouTube가 클라우드 서버 IP를 봇으로 차단(`Sign in to confirm you're not a bot`)해서 yt-dlp가 자막을 못 받아왔다. IP 차단은 코드로 못 뚫으므로 **Surfshark WireGuard VPN(일본 도쿄)** 경유로 우회.

## 변경
- **docker-compose.yml**: `gluetun` 사이드카(Surfshark WireGuard, 내장 HTTP 프록시 `:8888`) 추가. kiko는 `YTDLP_PROXY=http://kiko-gluetun:8888`로 **자막 요청만** VPN 경유 (Data API·OpenAI는 직결).
- **transcript.ts**: `YTDLP_PROXY` 설정 시 `--proxy` 사용. 자막을 `--sub-format json3`로 받아 `parseJson3`로 파싱 → **ffmpeg 불필요**, 자동자막 롤업 중복(`\n` 이벤트)은 trim으로 자동 제거.
- **deploy.yml**: `WIREGUARD_PRIVATE_KEY` 시크릿을 `.env.production`에 주입.
- version 1.2.2 → 1.2.3

## 검증 (실제 프로덕션 러너에서 수동 확인)
- [x] gluetun로 공인 IP가 일본(146.70.205.118)으로 전환됨
- [x] yt-dlp `--proxy http://gluetun:8888 --sub-format json3` → 봇 차단 없이 자막 다운로드 (json3 87 events)
- [x] parseJson3 단위 테스트 통과 (롤업 중복 필터링 포함)
- [x] typecheck 통과

## 배포 전 필수
- GitHub Secret **`WIREGUARD_PRIVATE_KEY`** 등록 완료 (`gh secret set`).