### PR TITLE
fix: 자막 sub-langs 좁혀 429 회피

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiko",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 30300",

--- a/src/lib/youtube/transcript.ts
+++ b/src/lib/youtube/transcript.ts
@@ -43,12 +43,18 @@ export async function fetchTranscript(
     const args = [
       "--write-auto-subs",
       "--write-subs",
+      // 원본 언어 트랙만. `${lang}.*` 와일드카드는 자동번역 트랙(ja-zh 등)까지
+      // 긁어 불필요한 요청이 늘고 YouTube 429(rate limit)를 앞당긴다.
       "--sub-langs",
-      `${lang}.*,${lang}`,
+      `${lang},${lang}-orig`,
       "--sub-format",
       "json3",
       "--skip-download",
       "--no-playlist",
+      "--retries",
+      "5",
+      "--extractor-retries",
+      "3",
       "-o",
       join(dir, "%(id)s.%(ext)s"),
     ];


### PR DESCRIPTION
## 문제
일부 영상에서 자막 fetch 시 `HTTP 429: Too Many Requests`. `--sub-langs ja.*,ja` 와일드카드가 자동번역 트랙(`ja-zh` 등)까지 긁어 불필요한 자막 요청이 늘고, 공유 VPN IP의 rate limit을 앞당김.

## 수정
- `--sub-langs`를 `ja,ja-orig`(원본 트랙만)로 좁힘 → 번역 트랙 배제 + 요청 수 감소.
- `--retries 5 --extractor-retries 3` 추가로 일시적 throttle 견디기.

## 검증 (프로덕션 러너, 실제 429 나던 영상 P1yqH9jwf14)
- [x] 좁힌 langs로 재요청 → 429 없이 `ja`/`ja-orig` json3 정상 다운로드
- [x] typecheck 통과